### PR TITLE
remove artifactory credentials from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,25 +17,6 @@ buildscript { //properties that you need to build the project
     }
 }
 
-// You can define this property in ~/.gradle/gradle.properties on your dev box.
-if (! project.hasProperty('cordaArtifactoryUsername') || !ext.cordaArtifactoryUsername?.trim()) {
-    ext.cordaArtifactoryUsername = System.getenv('CORDA_ARTIFACTORY_USERNAME')
-            ?: System.getenv('ARTIFACTORY_USERNAME')
-            ?: System.getProperty('corda.artifactory.username')
-}
-
-// You can define this property in ~/.gradle/gradle.properties on your dev box.
-if (! project.hasProperty('cordaArtifactoryPassword') || !ext.cordaArtifactoryPassword?.trim()) {
-    ext.cordaArtifactoryPassword = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
-            ?: System.getenv('ARTIFACTORY_PASSWORD')
-            ?: System.getProperty('corda.artifactory.password')
-}
-
-// Tell the user if we can't proceed.
-if (!ext.cordaArtifactoryUsername?.trim() || !ext.cordaArtifactoryPassword?.trim()) {
-    throw new IllegalArgumentException("ERROR: Either 'cordaArtifactoryUsername' or 'cordaArtifactoryPassword' is null!")
-}
-
 allprojects { //Properties that you need to compile your project (The application)
     apply from: "${rootProject.projectDir}/repositories.gradle"
     apply plugin: 'kotlin'


### PR DESCRIPTION
This PR removes the artifactory credentials stored in `build.gradle` that cause the build to fail, if not provided.
Also discussed in Issue #9 .

Feel free to accept it or reject it according with your internal workflow. 